### PR TITLE
Fixex bug unable to symlink and added readme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ add_subdirectory(gameplay)
 
 add_custom_target(create_link ALL
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/gdproject/gameplay/"
-    COMMAND "${CMAKE_COMMAND}" -E rm -rRf "${CMAKE_SOURCE_DIR}/gdproject/gameplay/bin/"
+    COMMAND "${CMAKE_COMMAND}" -E rm -rRf "${CMAKE_SOURCE_DIR}/gdproject/gameplay/bin"
     COMMAND "${CMAKE_COMMAND}" -E create_symlink "$<TARGET_FILE_DIR:gameplay>" "${CMAKE_SOURCE_DIR}/gdproject/gameplay/bin"
     COMMENT "Creating symbolic link to build directory"
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ add_subdirectory(gameplay)
 add_custom_target(create_link ALL
     COMMAND "${CMAKE_COMMAND}" -E make_directory "${CMAKE_SOURCE_DIR}/gdproject/gameplay/"
     COMMAND "${CMAKE_COMMAND}" -E rm -rRf "${CMAKE_SOURCE_DIR}/gdproject/gameplay/bin/"
-    COMMAND "${CMAKE_COMMAND}" -E create_symlink "$<TARGET_FILE_DIR:gameplay>" "${CMAKE_SOURCE_DIR}/gdproject/gameplay/bin/"
+    COMMAND "${CMAKE_COMMAND}" -E create_symlink "$<TARGET_FILE_DIR:gameplay>" "${CMAKE_SOURCE_DIR}/gdproject/gameplay/bin"
     COMMENT "Creating symbolic link to build directory"
 )
 

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # gdextension-template
+
+
+# Usage
+## Build GDExtention
+1. Navigate to the root of the git repo. 
+2. Run `cmake -S . -B ./build` to build the CMake at the root level of the Repo.
+3. Run `cmake --build ./build` to build based on the build system that was previously configured in the `/.build`.
+**NOTE: The first time it will be slow as it's building all the godot-cpp classes**
+
+
+## Add to Godot
+[![Godot Setup](https://cdn.conceptartempire.com/images/08/6123/00-featured-godot-logo.jpg)](https://thatonegamedev.com/wp-content/uploads/2023/03/godot4showcase.mp4)

--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@
 
 
 ## Add to Godot
+- Video guide
 [![Godot Setup](https://cdn.conceptartempire.com/images/08/6123/00-featured-godot-logo.jpg)](https://thatonegamedev.com/wp-content/uploads/2023/03/godot4showcase.mp4)


### PR DESCRIPTION
- There is a bug where the symlink will fail as it tries to create it in a `/bin` folder that does not exist rather than adding it as the bin folder. 
- Added a README with the build commands. 